### PR TITLE
Migrate from master and slave language

### DIFF
--- a/statistics_info/admin.py
+++ b/statistics_info/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import CompanyDeviceStatistic, BrandDeviceStatistic, SlaveDeviceStatistic, \
+from .models import CompanyDeviceStatistic, BrandDeviceStatistic, SubordinateDeviceStatistic, \
     CompanyImgStatistic, BrandImgStatistic
 
 
@@ -13,9 +13,9 @@ class BrandDeviceStatisticAdmin(admin.ModelAdmin):
 admin.site.register(BrandDeviceStatistic, BrandDeviceStatisticAdmin)
 
 
-class SlaveDeviceStatisticAdmin(admin.ModelAdmin):
-    list_display = ("id", "slave", "num", "created_at", )
-admin.site.register(SlaveDeviceStatistic, SlaveDeviceStatisticAdmin)
+class SubordinateDeviceStatisticAdmin(admin.ModelAdmin):
+    list_display = ("id", "subordinate", "num", "created_at", )
+admin.site.register(SubordinateDeviceStatistic, SubordinateDeviceStatisticAdmin)
 
 
 class CompanyImgStatisticAdmin(admin.ModelAdmin):

--- a/statistics_info/daily_statistic/device_statistic.py
+++ b/statistics_info/daily_statistic/device_statistic.py
@@ -6,8 +6,8 @@ import traceback
 import datetime
 from concurrent.futures import wait
 from concurrent.futures import ThreadPoolExecutor as Pool
-from system_info.models import Brand, Company, Slave
-from statistics_info.models import BrandDeviceStatistic, CompanyDeviceStatistic, SlaveDeviceStatistic
+from system_info.models import Brand, Company, Subordinate
+from statistics_info.models import BrandDeviceStatistic, CompanyDeviceStatistic, SubordinateDeviceStatistic
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 
 
@@ -77,11 +77,11 @@ class DeviceStatistic(object):
     def start(self):
         logger.info("start archive upload statistic %s", self.archive_path)
         archive_stat = {
-            "slave": {},
+            "subordinate": {},
             "on": {},
             "dm_dn": {},
         }
-        slave_statistic = archive_stat["slave"]
+        subordinate_statistic = archive_stat["subordinate"]
         dm_dn_statistic = archive_stat["dm_dn"]
         on_statistic = archive_stat["on"]
         logger.info("start statistic archive path %s", self.archive_path)
@@ -102,7 +102,7 @@ class DeviceStatistic(object):
                     logging.error("archive dir no exist %s", last_archive_dir)
                     continue
 
-                slave_statistic[archive] = {
+                subordinate_statistic[archive] = {
                     "name": archive,
                     "num": len(os.listdir(last_archive_dir)) - 1,
                 }
@@ -138,28 +138,28 @@ class DeviceStatistic(object):
             s = json.dumps(statistic)
             f.write(s)
             f.flush()
-        slave_statistics = statistic["slave"]
+        subordinate_statistics = statistic["subordinate"]
         company_statistics = statistic["on"]
         brand_statistics = statistic["dm_dn"]
 
-        for slave in slave_statistics:
+        for subordinate in subordinate_statistics:
             try:
-                slave_obj = Slave.objects.get(mac=slave)
+                subordinate_obj = Subordinate.objects.get(mac=subordinate)
             except ObjectDoesNotExist:
-                logger.info("new slave insert %s", slave)
-                slave_obj = Slave(
-                    mac=slave
+                logger.info("new subordinate insert %s", subordinate)
+                subordinate_obj = Subordinate(
+                    mac=subordinate
                 )
-                slave_obj.save()
+                subordinate_obj.save()
             except MultipleObjectsReturned:
-                logger.error("more than one slave %s", slave)
+                logger.error("more than one subordinate %s", subordinate)
                 continue
 
-            slave_device_statistic = SlaveDeviceStatistic(
-                slave=slave_obj,
-                num=slave_statistics[slave]["num"],
+            subordinate_device_statistic = SubordinateDeviceStatistic(
+                subordinate=subordinate_obj,
+                num=subordinate_statistics[subordinate]["num"],
             )
-            slave_device_statistic.save()
+            subordinate_device_statistic.save()
 
         for company in company_statistics:
             try:

--- a/statistics_info/migrations/0001_initial.py
+++ b/statistics_info/migrations/0001_initial.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name='SlaveStatistic',
+            name='SubordinateStatistic',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('ip', models.CharField(default=None, help_text='公司名称', max_length=65, verbose_name='公司名称')),
@@ -51,9 +51,9 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True, help_text='创建时间', verbose_name='创建时间')),
             ],
             options={
-                'verbose_name': 'slaveStatistic信息',
-                'verbose_name_plural': 'slaveStatistic信息',
-                'db_table': 'slaveStatistic',
+                'verbose_name': 'subordinateStatistic信息',
+                'verbose_name_plural': 'subordinateStatistic信息',
+                'db_table': 'subordinateStatistic',
             },
         ),
     ]

--- a/statistics_info/migrations/0003_auto_20181130_1218.py
+++ b/statistics_info/migrations/0003_auto_20181130_1218.py
@@ -7,7 +7,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('system_info', '0005_slave'),
+        ('system_info', '0005_subordinate'),
         ('statistics_info', '0002_branddailyimg_companydailyimg'),
     ]
 
@@ -69,17 +69,17 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name='SlaveDeviceStatistic',
+            name='SubordinateDeviceStatistic',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('num', models.IntegerField(default=None, help_text='设备数', verbose_name='设备数')),
                 ('created_at', models.DateTimeField(auto_now_add=True, help_text='创建时间', verbose_name='创建时间')),
-                ('slave', models.ForeignKey(help_text='从', on_delete=django.db.models.deletion.CASCADE, related_name='slave_device_statistic', to='system_info.Slave', verbose_name='从')),
+                ('subordinate', models.ForeignKey(help_text='从', on_delete=django.db.models.deletion.CASCADE, related_name='subordinate_device_statistic', to='system_info.Subordinate', verbose_name='从')),
             ],
             options={
-                'verbose_name_plural': 'slaveStatistic信息',
-                'db_table': 'slaveDeviceStatistic',
-                'verbose_name': 'slaveStatistic信息',
+                'verbose_name_plural': 'subordinateStatistic信息',
+                'db_table': 'subordinateDeviceStatistic',
+                'verbose_name': 'subordinateStatistic信息',
             },
         ),
         migrations.RemoveField(
@@ -95,7 +95,7 @@ class Migration(migrations.Migration):
             name='firmUploadImgStatistic_id',
         ),
         migrations.DeleteModel(
-            name='SlaveStatistic',
+            name='SubordinateStatistic',
         ),
         migrations.DeleteModel(
             name='BrandDailyImg',

--- a/statistics_info/migrations/0004_auto_20181130_1735.py
+++ b/statistics_info/migrations/0004_auto_20181130_1735.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             options={'verbose_name': '厂商上传设备数统计', 'verbose_name_plural': '厂商上传设备数统计'},
         ),
         migrations.AlterModelOptions(
-            name='slavedevicestatistic',
-            options={'verbose_name': 'slave设备数统计', 'verbose_name_plural': 'slave设备数统计'},
+            name='subordinatedevicestatistic',
+            options={'verbose_name': 'subordinate设备数统计', 'verbose_name_plural': 'subordinate设备数统计'},
         ),
     ]

--- a/statistics_info/models.py
+++ b/statistics_info/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from system_info.models import Brand, Slave, Company
+from system_info.models import Brand, Subordinate, Company
 # Create your models here.
 
 
@@ -27,16 +27,16 @@ class BrandDeviceStatistic(models.Model):
         db_table = 'brandDeviceStatistic'
 
 
-class SlaveDeviceStatistic(models.Model):
-    slave = models.ForeignKey(Slave, related_name="slave_device_statistic", on_delete=models.CASCADE,
+class SubordinateDeviceStatistic(models.Model):
+    subordinate = models.ForeignKey(Subordinate, related_name="subordinate_device_statistic", on_delete=models.CASCADE,
                               verbose_name="从", help_text="从")
     num = models.IntegerField(default=None, verbose_name="设备数", help_text="设备数")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="创建时间", help_text="创建时间")
 
     class Meta:
-        verbose_name = "slave设备数统计"
+        verbose_name = "subordinate设备数统计"
         verbose_name_plural = verbose_name
-        db_table = 'slaveDeviceStatistic'
+        db_table = 'subordinateDeviceStatistic'
 
 
 class CompanyImgStatistic(models.Model):

--- a/statistics_info/views.py
+++ b/statistics_info/views.py
@@ -14,7 +14,7 @@ import json
 from rest_framework.views import APIView
 # Create your views here.
 import datetime
-from .models import Company,SlaveDeviceStatistic,Slave
+from .models import Company,SubordinateDeviceStatistic,Subordinate
 
 from django.http import HttpResponse
 import time
@@ -64,13 +64,13 @@ class MacOverView(APIView):
         temp_array_total.append({'title':'总设备数','count':total_num,'icon':'md-person-add','color': '#2d8cf0'})
         result['top'] = temp_array_total + temp_array
 
-        #center left data slaveDeviceStatistic
-        slave_datas = SlaveDeviceStatistic.objects.filter(created_at__gte=str(formate_time))
+        #center left data subordinateDeviceStatistic
+        subordinate_datas = SubordinateDeviceStatistic.objects.filter(created_at__gte=str(formate_time))
         result['center_left']=[]
-        for slave in slave_datas:
+        for subordinate in subordinate_datas:
             item = {}
-            item['name'] = Slave.objects.get(id=slave.slave_id).mac
-            item['value'] = slave.num
+            item['name'] = Subordinate.objects.get(id=subordinate.subordinate_id).mac
+            item['value'] = subordinate.num
             result['center_left'].append(item)
 
         return Response(data=self.get_return_result(self,status.HTTP_200_OK,result,'success'))

--- a/system_info/migrations/0005_slave.py
+++ b/system_info/migrations/0005_slave.py
@@ -11,17 +11,17 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='Slave',
+            name='Subordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(blank=True, default=None, max_length=65, verbose_name='slave别名')),
+                ('name', models.CharField(blank=True, default=None, max_length=65, verbose_name='subordinate别名')),
                 ('mac', models.CharField(blank=True, default=None, max_length=65, unique=True, verbose_name='mac地址')),
                 ('ip', models.CharField(blank=True, default=None, max_length=65, verbose_name='ip地址')),
                 ('created_at', models.DateTimeField(auto_now_add=True, help_text='创建时间', verbose_name='创建时间')),
                 ('updated_at', models.DateTimeField(auto_now=True, help_text='更新时间', verbose_name='更新时间')),
             ],
             options={
-                'db_table': 'slave',
+                'db_table': 'subordinate',
                 'verbose_name': '从机器信息',
                 'verbose_name_plural': '从机器信息',
             },

--- a/system_info/migrations/0006_auto_20181130_1728.py
+++ b/system_info/migrations/0006_auto_20181130_1728.py
@@ -6,18 +6,18 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('system_info', '0005_slave'),
+        ('system_info', '0005_subordinate'),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='ip',
             field=models.CharField(blank=True, max_length=65, null=True, verbose_name='ip地址'),
         ),
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='name',
-            field=models.CharField(blank=True, max_length=65, null=True, verbose_name='slave别名'),
+            field=models.CharField(blank=True, max_length=65, null=True, verbose_name='subordinate别名'),
         ),
     ]

--- a/system_info/migrations/0007_auto_20181130_1735.py
+++ b/system_info/migrations/0007_auto_20181130_1735.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterModelOptions(
-            name='slave',
-            options={'verbose_name': 'Slave信息', 'verbose_name_plural': 'Slave信息'},
+            name='subordinate',
+            options={'verbose_name': 'Subordinate信息', 'verbose_name_plural': 'Subordinate信息'},
         ),
     ]

--- a/system_info/models.py
+++ b/system_info/models.py
@@ -72,17 +72,17 @@ class AliasChName(models.Model):
         return self.name
 
 
-class Slave(models.Model):
-    name = models.CharField(max_length=65, blank=True, null=True, verbose_name="slave别名")
+class Subordinate(models.Model):
+    name = models.CharField(max_length=65, blank=True, null=True, verbose_name="subordinate别名")
     mac = models.CharField(max_length=65, blank=True, default=None, verbose_name="mac地址", unique=True)
     ip = models.CharField(max_length=65, blank=True, null=True, verbose_name="ip地址")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="创建时间", help_text="创建时间")
     updated_at = models.DateTimeField(auto_now=True, verbose_name="更新时间", help_text="更新时间")
 
     class Meta:
-        verbose_name = "Slave信息"
+        verbose_name = "Subordinate信息"
         verbose_name_plural = verbose_name
-        db_table = "slave"
+        db_table = "subordinate"
 
     def __str__(self):
         return self.mac


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.